### PR TITLE
Update Navbar logo text and enhance Sidebar functionality with mini toggle and improved accessibility

### DIFF
--- a/src/components/Shared/Navbar.jsx
+++ b/src/components/Shared/Navbar.jsx
@@ -24,7 +24,7 @@ const Navbar = ({ toggleSidebar }) => {
         <Link to="/">
           <Logo>
             <FaCode />
-            <LogoText>Code Editor</LogoText>
+            <LogoText>CodeConclave</LogoText>
           </Logo>
         </Link>
       </NavbarLeft>

--- a/src/components/Shared/Sidebar.jsx
+++ b/src/components/Shared/Sidebar.jsx
@@ -1,61 +1,137 @@
-import { NavLink } from 'react-router-dom';
+import React, { useEffect, useState, useRef } from 'react';
+import { NavLink, Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { FaHome, FaShareAlt, FaCog, FaQuestionCircle } from 'react-icons/fa';
+import {
+  FaHome,
+  FaShareAlt,
+  FaCog,
+  FaQuestionCircle,
+  FaCode,
+  FaChevronLeft,
+  FaChevronRight,
+  FaCompressArrowsAlt,
+} from 'react-icons/fa';
+
+const STORAGE_KEY = 'cc_sidebar_mini';
 
 const Sidebar = ({ isOpen }) => {
+  const [mini, setMini] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, mini ? 'true' : 'false');
+    } catch {}
+  }, [mini]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const isCmd = e.metaKey || e.ctrlKey;
+      if (isCmd && (e.key === 'b' || e.key === 'B')) {
+        e.preventDefault();
+        setMini((s) => !s);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const toggleMini = () => setMini((s) => !s);
+
   return (
-    <SidebarContainer isOpen={isOpen}>
+    <SidebarContainer isOpen={isOpen} $mini={mini} role="navigation" aria-label="Main sidebar">
+      <SidebarBrand $mini={mini}>
+        <BrandLink to="/" aria-label="Go to home">
+          <BrandIcon title="Code Editor">
+            <FaCode />
+          </BrandIcon>
+          <BrandText $mini={mini}>Code Editor</BrandText>
+        </BrandLink>
+
+        <MiniToggle
+          onClick={toggleMini}
+          aria-pressed={mini}
+          title={mini ? 'Expand sidebar (Ctrl/Cmd + B)' : 'Collapse to icons (Ctrl/Cmd + B)'}
+        >
+          {mini ? <FaChevronRight /> : <FaChevronLeft />}
+        </MiniToggle>
+      </SidebarBrand>
+
       <SidebarNav>
-        <NavItem>
+        <NavItem $mini={mini}>
           <NavLink to="/dashboard" end>
             <FaHome />
-            <NavText>Dashboard</NavText>
+            <NavText $mini={mini}>Dashboard</NavText>
           </NavLink>
         </NavItem>
-        <NavItem>
+
+        <NavItem $mini={mini}>
           <NavLink to="/shared">
             <FaShareAlt />
-            <NavText>Shared with me</NavText>
+            <NavText $mini={mini}>Shared with me</NavText>
           </NavLink>
         </NavItem>
+
         <NavDivider />
-        <NavItem>
+
+        <NavItem $mini={mini}>
           <NavLink to="/settings">
             <FaCog />
-            <NavText>Settings</NavText>
+            <NavText $mini={mini}>Settings</NavText>
           </NavLink>
         </NavItem>
-        <NavItem>
+
+        <NavItem $mini={mini}>
           <NavLink to="/help">
             <FaQuestionCircle />
-            <NavText>Help</NavText>
+            <NavText $mini={mini}>Help</NavText>
           </NavLink>
         </NavItem>
       </SidebarNav>
 
-      <SidebarFooter>
-        <FooterText>Code Editor v1.0.0</FooterText>
+      <SidebarFooter $mini={mini}>
+        <FooterLeft>
+          <FooterText $mini={mini}>Code Editor v1.0.0</FooterText>
+        </FooterLeft>
+
+        <FooterAction onClick={() => setMini(false)} title="Reset to full sidebar">
+          <FaCompressArrowsAlt />
+        </FooterAction>
       </SidebarFooter>
     </SidebarContainer>
   );
 };
 
+/* Styled components -> edited BrandText, NavText and FooterText so mobile always shows full text */
 const SidebarContainer = styled.div`
+  --full-width: 250px;
+  --mini-width: 72px;
+  width: ${(p) => (p.$mini ? 'var(--mini-width)' : 'var(--full-width)')};
+  min-width: ${(p) => (p.$mini ? 'var(--mini-width)' : 'var(--full-width)')};
+  transition: width 220ms ease, transform 220ms ease;
+  display: flex;
+  flex-direction: column;
   position: fixed;
   top: 60px;
   left: 0;
   bottom: 0;
-  width: 250px;
+  z-index: 5;
   background-color: var(--color-surface);
   border-right: 1px solid var(--color-border);
-  display: flex;
-  flex-direction: column;
-  transition: transform 0.3s ease;
-  z-index: 5;
-  transform: translateX(${props => (props.isOpen ? '0' : '-100%')});
-  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.08);
 
-  /* Desktop: always visible */
+  transform: translateX(${(p) => (p.isOpen ? '0' : '-100%')});
   @media (min-width: 768px) {
     transform: translateX(0);
     position: static;
@@ -63,21 +139,103 @@ const SidebarContainer = styled.div`
   }
 `;
 
+const SidebarBrand = styled.div`
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--color-border);
+  justify-content: space-between;
+
+  ${(p) =>
+    p.$mini &&
+    `
+    padding-left: 12px;
+    padding-right: 8px;
+  `}
+`;
+
+const BrandLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--color-text-primary);
+  font-weight: 600;
+  font-size: 15px;
+`;
+
+const BrandIcon = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--color-surface-light);
+  color: var(--color-primary);
+  svg {
+    font-size: 16px;
+    display: block;
+  }
+`;
+
+/* ---- FIXED: show brand text on mobile always; hide on desktop to avoid duplicate with top Navbar ---- */
+const BrandText = styled.span`
+  white-space: nowrap;
+
+  /* show on small screens (mobile) */
+  @media (max-width: 767px) {
+    display: inline;
+  }
+
+  /* hide on desktop so top Navbar remains single brand */
+  @media (min-width: 768px) {
+    display: none;
+  }
+`;
+
+const MiniToggle = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-surface);
+  }
+
+  @media (max-width: 720px) {
+    display: none;
+  }
+`;
+
 const SidebarNav = styled.ul`
-  list-style-type: none;
-  padding: 0;
+  list-style: none;
   margin: 0;
+  padding: 8px 0;
   flex: 1;
+  overflow: auto;
 `;
 
 const NavItem = styled.li`
   a {
     display: flex;
     align-items: center;
-    padding: 12px 20px;
+    gap: 12px;
+    padding: 10px 14px;
     color: var(--color-text-secondary);
     text-decoration: none;
     font-size: 14px;
+    border-radius: 8px;
+    margin: 4px 8px;
+    transition: background 120ms ease;
 
     &:hover {
       background-color: var(--color-background);
@@ -87,8 +245,7 @@ const NavItem = styled.li`
       color: var(--color-primary);
       background-color: var(--color-surface-light);
       border-left: 3px solid var(--color-primary);
-      padding-left: 17px;
-
+      padding-left: calc(14px - 3px);
       svg {
         color: var(--color-primary);
       }
@@ -96,33 +253,104 @@ const NavItem = styled.li`
 
     svg {
       font-size: 16px;
-      margin-right: 12px;
       color: var(--color-text-tertiary);
+      flex-shrink: 0;
     }
+  }
+
+  /* center icons when container is mini (desktop only) */
+  @media (min-width: 768px) {
+    ${(p) =>
+      p.$mini &&
+      `
+      a { justify-content: center; padding-left: 0; padding-right: 0; }
+      a svg { margin-right: 0; }
+    `}
   }
 `;
 
+/* ---- FIXED: show nav text on mobile even if mini = true ---- */
 const NavText = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  /* if mini on desktop hide text */
+  ${(p) =>
+    p.$mini &&
+    `
+    @media (min-width: 768px) {
+      display: none;
+    }
+  `}
+
+  /* always show on small screens */
+  @media (max-width: 767px) {
+    display: inline;
+  }
 `;
 
 const NavDivider = styled.div`
   height: 1px;
   background-color: var(--color-border);
-  margin: 10px 0;
+  margin: 10px 8px;
 `;
 
 const SidebarFooter = styled.div`
-  padding: 15px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
   border-top: 1px solid var(--color-border);
+
+  ${(p) =>
+    p.$mini &&
+    `
+    padding-left: 8px;
+    padding-right: 8px;
+  `}
 `;
 
+const FooterLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+/* ---- FIXED: show footer text on mobile even if mini = true ---- */
 const FooterText = styled.div`
   font-size: 12px;
   color: var(--color-text-tertiary);
-  text-align: center;
+
+  ${(p) =>
+    p.$mini &&
+    `
+    @media (min-width: 768px) {
+      display: none;
+    }
+  `}
+
+  @media (max-width: 767px) {
+    display: block;
+  }
+`;
+
+const FooterAction = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-surface);
+  }
 `;
 
 export default Sidebar;


### PR DESCRIPTION
### Summary
Adds a persistent "mini" (icons-only) sidebar mode with:
- Header toggle to collapse/expand the sidebar
- Keyboard shortcut: Ctrl/Cmd + B
- Persistence via localStorage
- Mobile behaviour unchanged (navbar still controls visibility)

### Changes
- Replaced `src/components/Shared/Sidebar.jsx` 
- And Changed The App Name from Code Editor ---> CodeConclave
<img width="1364" height="591" alt="image" src="https://github.com/user-attachments/assets/b2b11eb0-e6e8-4b10-ac1f-214bdc8d57d3" />
<img width="1365" height="600" alt="image" src="https://github.com/user-attachments/assets/591eb33c-6334-474b-9b97-15a5178c648d" />
- No route names changed

### How to test
1. Start the dev server.
2. On desktop: click the chevron toggle to collapse/expand; press Ctrl/Cmd+B to toggle.
3. On mobile (<768px): sidebar should show full text even when mini is enabled.
4. Reload the page — mini preference should persist.

### Checklist
- [ ] Code builds locally
- [ ] Behavior tested on desktop + mobile
- [ ] Includes accessible attributes (aria-pressed, labels)
- [ ] Screenshots/GIF attached (desktop + mobile)
