### PR TITLE
fix(ui): render project menu outside link, allow dropdown overflow & fix dashboard search sizing & Made Changes in Project Title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/assets/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Code Editor</title>
+    <title>CodeConclave</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Shared/ProjectCard.jsx
+++ b/src/components/Shared/ProjectCard.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { 
   FaCode, FaTrash, FaShareAlt, FaEllipsisV, FaLock, FaGlobe, 
-  FaUser, FaPencilAlt, FaExternalLinkAlt
+  FaUser, FaPencilAlt
 } from 'react-icons/fa';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -43,7 +43,7 @@ const ProjectCard = ({ project, onDelete, onRename, onShare, isOwner }) => {
   const handleMenuClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    setShowMenu(!showMenu);
+    setShowMenu((s) => !s);
   };
   
   const handleDeleteClick = (e) => {
@@ -83,11 +83,14 @@ const ProjectCard = ({ project, onDelete, onRename, onShare, isOwner }) => {
     }
   };
   
-  const handleCardClick = (e) => {
-    // Only navigate if we're not in rename mode
+  // Keep a small helper in case you want to programmatically navigate (not strictly needed)
+  const handleNavigate = (e) => {
+    // If renaming is active, don't navigate
     if (isRenaming) {
-      e.preventDefault();
+      e && e.preventDefault();
+      return;
     }
+    // Let Link handle navigation by default when clicking the <Link> elements.
   };
 
   // Format the creation date
@@ -97,13 +100,14 @@ const ProjectCard = ({ project, onDelete, onRename, onShare, isOwner }) => {
   
   return (
     <CardContainer>
-      <Link to={`/projects/${project._id}`} onClick={handleCardClick}>
-        <CardContent>
-          <CardHeader>
+      <CardContent>
+        <CardHeader>
+          {/* Left side: clickable area (link) containing icon + title */}
+          <HeaderLeft as={CardLink} to={`/projects/${project._id}`} onClick={handleNavigate}>
             <CardIcon>
               <FaCode />
             </CardIcon>
-            
+
             {isRenaming ? (
               <RenameForm onSubmit={handleRenameSubmit}>
                 <RenameInput
@@ -113,43 +117,52 @@ const ProjectCard = ({ project, onDelete, onRename, onShare, isOwner }) => {
                   onBlur={handleRenameSubmit}
                   onClick={(e) => e.stopPropagation()}
                   maxLength={50}
+                  aria-label="Rename project"
                 />
               </RenameForm>
             ) : (
-              <CardTitle>{project.name}</CardTitle>
+              <CardTitle title={project.name}>{project.name}</CardTitle>
             )}
-            
-            {/* This is the 3-dot menu button */}
-            <MenuButton onClick={handleMenuClick} aria-label="Project options">
+          </HeaderLeft>
+
+          {/* Menu button lives outside the Link so the dropdown is not inside the anchor */}
+          <MenuArea>
+            <MenuButton
+              onClick={handleMenuClick}
+              aria-label="Project options"
+              aria-haspopup="menu"
+              aria-expanded={showMenu}
+            >
               <FaEllipsisV />
             </MenuButton>
-            
-            {/* Menu with all required options */}
+
             {showMenu && (
-              <MenuDropdown ref={menuRef}>
-                               
-                <MenuItem onClick={handleRenameClick}>
+              <MenuDropdown ref={menuRef} role="menu" aria-label={`Options for ${project.name}`}>
+                <MenuItem onClick={handleRenameClick} role="menuitem" tabIndex={0}>
                   <FaPencilAlt />
                   <span>Rename</span>
                 </MenuItem>
                 
-                <MenuItem onClick={handleShareClick}>
+                <MenuItem onClick={handleShareClick} role="menuitem" tabIndex={0}>
                   <FaShareAlt />
                   <span>Share</span>
                 </MenuItem>
                 
-                <MenuItem onClick={handleDeleteClick} danger>
+                <MenuItem onClick={handleDeleteClick} danger role="menuitem" tabIndex={0}>
                   <FaTrash />
                   <span>Delete</span>
                 </MenuItem>
               </MenuDropdown>
             )}
-          </CardHeader>
-          
+          </MenuArea>
+        </CardHeader>
+
+        {/* Clickable description + footer area — also wrapped with Link so clicking them opens project */}
+        <ContentLink to={`/projects/${project._id}`} onClick={handleNavigate}>
           <CardDescription>
             {project.description || 'No description provided'}
           </CardDescription>
-          
+
           <CardFooter>
             <CardMeta>
               <VisibilityBadge isPublic={project.isPublic}>
@@ -171,18 +184,22 @@ const ProjectCard = ({ project, onDelete, onRename, onShare, isOwner }) => {
               </OwnerName>
             </CardOwner>
           </CardFooter>
-        </CardContent>
-      </Link>
+        </ContentLink>
+      </CardContent>
     </CardContainer>
   );
 };
+
+/* -------------------------
+   Styled components
+   ------------------------- */
 
 const CardContainer = styled.div`
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-  overflow: hidden;
+  overflow: visible; /* allow dropdown to appear outside the card if needed */
   transition: transform 0.2s, box-shadow 0.2s;
   height: 100%;
   position: relative;
@@ -191,15 +208,9 @@ const CardContainer = styled.div`
     transform: translateY(-4px);
     box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
   }
-  
-  a {
-    text-decoration: none;
-    color: inherit;
-    display: block;
-    height: 100%;
-  }
 `;
 
+/* CardContent stays the same */
 const CardContent = styled.div`
   padding: 20px;
   display: flex;
@@ -207,13 +218,37 @@ const CardContent = styled.div`
   height: 100%;
 `;
 
+/* Header is now split: left link area and menu area */
 const CardHeader = styled.div`
   display: flex;
   align-items: center;
   position: relative;
   margin-bottom: 10px;
+  gap: 12px;
 `;
 
+/* a Link-styled wrapper used for left header area (icon + title) */
+const CardLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+  flex: 1;
+  min-width: 0; /* allow child text truncation */
+`;
+
+/* HeaderLeft is same shape as before but typed as CardLink */
+const HeaderLeft = styled(CardLink)``;
+
+/* MenuArea holds the button + dropdown; it's outside the link so dropdown is positioned within card */
+const MenuArea = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+/* Keep the icon block */
 const CardIcon = styled.div`
   display: flex;
   align-items: center;
@@ -223,9 +258,8 @@ const CardIcon = styled.div`
   background-color: var(--color-surface-light);
   color: var(--color-primary);
   border-radius: 8px;
-  margin-right: 12px;
   flex-shrink: 0;
-  
+
   svg {
     font-size: 18px;
   }
@@ -236,12 +270,12 @@ const CardTitle = styled.h3`
   font-size: 16px;
   font-weight: 600;
   color: var(--color-text-primary);
-  flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
+/* Rename input styles unchanged */
 const RenameForm = styled.form`
   flex: 1;
   margin-right: 10px;
@@ -259,7 +293,7 @@ const RenameInput = styled.input`
   background: var(--color-background);
 `;
 
-// The 3-dot menu button
+/* Menu button unchanged */
 const MenuButton = styled.button`
   background-color: transparent;
   border: none;
@@ -271,32 +305,32 @@ const MenuButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  
+
   &:hover {
     background-color: var(--color-surface);
     color: var(--color-text-secondary);
   }
-  
+
   svg {
     font-size: 14px;
   }
 `;
 
-// Dropdown menu that appears on click
+/* Dropdown positioned relative to MenuArea (so it visually sits inside card) */
 const MenuDropdown = styled.div`
   position: absolute;
-  top: 100%;
+  top: calc(100% + 6px); /* just below the button */
   right: 0;
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
-  z-index: 100;
-  min-width: 150px;
+  box-shadow: 0 6px 12px rgba(0,0,0,0.12);
   overflow: hidden;
-  margin-top: 5px;
+  z-index: 1000;
+  min-width: 160px;
 `;
 
+/* Menu item unchanged */
 const MenuItem = styled.button`
   display: flex;
   align-items: center;
@@ -310,29 +344,37 @@ const MenuItem = styled.button`
   color: ${props => props.danger ? 'var(--color-danger)' : 'var(--color-text-secondary)'};
   cursor: pointer;
   transition: 0.2s;
-  
+
   &:hover {
-    background-color: ${props => props.danger ? 'rgba(239, 68, 68, 0.1)' : 'var(--color-surface)'};
+    background-color: ${props => props.danger ? 'rgba(239, 68, 68, 0.06)' : 'var(--color-surface)'};
   }
-  
+
   svg {
     font-size: 14px;
     color: ${props => props.danger ? 'var(--color-danger)' : 'var(--color-text-tertiary)'};
   }
-  
+
   &:not(:last-child) {
     border-bottom: 1px solid var(--color-border);
   }
 `;
 
+/* ContentLink wraps the description + footer area so they remain clickable */
+const ContentLink = styled(Link)`
+  display: block;
+  color: inherit;
+  text-decoration: none;
+`;
+
+/* Description + footer unchanged */
 const CardDescription = styled.p`
   margin: 0 0 20px;
   color: var(--color-text-secondary);
   font-size: 14px;
   line-height: 1.5;
   flex: 1;
-  
-  // Display only 2 lines with ellipsis
+
+  /* Display only 2 lines with ellipsis */
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -361,7 +403,7 @@ const VisibilityBadge = styled.div`
   background-color: ${props => props.isPublic ? 'rgba(34, 197, 94, 0.1)' : 'var(--color-surface)'};
   padding: 4px 8px;
   border-radius: 4px;
-  
+
   svg {
     font-size: 10px;
   }
@@ -387,7 +429,7 @@ const OwnerAvatar = styled.div`
   align-items: center;
   justify-content: center;
   color: var(--color-text-secondary);
-  
+
   svg {
     font-size: 12px;
   }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext } from 'react'; 
 import styled from 'styled-components';
 import { getProjects, createProject, deleteProject, updateProject } from '../services/projectService';
 import ProjectCard from '../components/Shared/ProjectCard';
@@ -236,15 +236,18 @@ const Controls = styled.div`
   }
 `;
 
+/* --- Updated SearchBar and SearchInput styles --- */
 const SearchBar = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
+  height: 36px; /* consistent control height */
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: 6px;
   padding: 0 10px;
-  
+  box-sizing: border-box;
+
   @media (min-width: 768px) {
     width: 250px;
   }
@@ -254,16 +257,30 @@ const SearchIcon = styled.div`
   color: var(--color-text-tertiary);
   display: flex;
   align-items: center;
+  margin-right: 8px;
+  flex: 0 0 auto;
 `;
 
 const SearchInput = styled.input`
   border: none;
-  padding: 8px 10px;
-  flex-grow: 1;
+  padding: 0;
+  height: 100%;
+  width: 100%;
   outline: none;
   font-size: 14px;
   background: transparent;
   color: var(--color-text-primary);
+  flex: 1 1 auto;
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: var(--color-text-tertiary);
+    opacity: 0.9;
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
 `;
 
 const FilterGroup = styled.div`


### PR DESCRIPTION
…fix dashboard search sizing

Summary:
- Move project card menu button and dropdown outside the anchor/link area so the dropdown is visually contained inside the card and no longer conflicts with navigation.
- Allow dropdown to overflow the card container (overflow: visible) and increase dropdown z-index so it appears above other elements.
- Fix Dashboard search input layout: set a consistent control height, use flex alignment and ensure the input expands properly so it does not collapse when focused.

Files changed:
- src/components/Shared/ProjectCard.jsx (menu moved outside the Link, MenuArea added, MenuDropdown positioning adjusted)
- src/pages/Dashboard.jsx (SearchBar and SearchInput styles updated for fixed height / flex layout)

How to test:
1. Open Dashboard and click anywhere on a card (except the three-dot menu) — it should navigate to the project as before.
2. Click the three-dot menu on a project card — the dropdown (Rename / Share / Delete) should appear anchored to the button and fully visible (not clipped).
3. Click/focus the 'Search projects...' input — the input should be vertically centered, have consistent height, and accept typing without collapsing.
4. Verify behavior at desktop and mobile widths.

Notes:
- These are styling/structure-only changes; no functionality or API behavior was changed.
- If this PR closes an issue, include: Fixes: #<ISSUE_NUMBER>